### PR TITLE
Update supervisor-programming.md

### DIFF
--- a/docs/guide/supervisor-programming.md
+++ b/docs/guide/supervisor-programming.md
@@ -70,7 +70,7 @@ int main() {
 
   // do this once only
   Node *robot_node = supervisor->getFromDef("MY_ROBOT");
-  if (node_robot == NULL) {
+  if (robot_node == NULL) {
     std:cerr << "No DEF MY_ROBOT node found in the current world file" << std::endl;
     exit(1);
   }


### PR DESCRIPTION
Changed the typo identified in issue#2788, for the supervisor documentation code for C++. 


**Description**
Converted "node_robot" object to "robot_node" object, in the supervisor.md file.

**Related Issues**
This pull-request fixes issue #2788

**Documentation**
If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
https://github.com/cyberbotics/webots/blob/master/docs/guide/supervisor-programming.md?version=master
